### PR TITLE
Set env in the helm_lint job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,7 @@ workflows:
     jobs:
       - hmpps/helm_lint:
           name: helm_lint
+          env: test
       - hmpps/build_multiplatform_docker:
           name: build_docker
           filters:


### PR DESCRIPTION
This defaults to `dev`, and we don’t have a `dev` environment