### PR TITLE
Run container as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
+ARG uid=2000
+
 FROM wiremock/wiremock:2.32.0 as base
+
+USER 2000
 
 ADD mappings /home/wiremock/mappings


### PR DESCRIPTION
By default, Wiremock runs as root, something which is not allowed by the Cloud Platform security config. This sets the `uid` variable to allow the stubs to be owned by a non-root user, and then sets the acting user to the same UID.