### PR TITLE
Update probe endpoints

### DIFF
--- a/helm_deploy/hmpps-community-accommodation-wiremock/values.yaml
+++ b/helm_deploy/hmpps-community-accommodation-wiremock/values.yaml
@@ -19,17 +19,14 @@ generic-service:
 
   livenessProbe:
     httpGet:
-      path: /ping
+      path: /__admin
 
   readinessProbe:
     httpGet:
-      path: /ping
+      path: /__admin
 
   custommetrics:
-    enabled: true
-    scrapeInterval: 15s
-    metricsPath: /metrics
-    metricsPort: 3001
+    enabled: false
 
   allowlist:
     office: '217.33.148.210/32'


### PR DESCRIPTION
`/ping` does not exist. Also disable the customMetrics endpoint. We don’t need it