### PR TITLE
Add helper scripts and new stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,13 @@ can run the following command to update the Wiremock mappings:
 ```bash
 script/generate_mappings
 ```
+
+And this command to update the API migrations:
+
+```bash
+script/generate_migrations /path/to/api/directory
+```
+
+Where `/path/to/api/directory` is the location of your API repo
+directory. You'll then need to push up a branch and open a pull
+request to change the migrations.

--- a/README.md
+++ b/README.md
@@ -33,3 +33,17 @@ docker run -p 9999:8080 hmpps-community-accommodation-wiremock
 ```
 
 (Replace `9999` with the port you want Wiremock to be accessible from)
+
+## Utils
+
+As part of our user testing procedure, we want to ensure that the
+data we have in the API matches up with the data that we're returning
+from Wiremock. To help us with this, we have a list of known offenders
+and users in the `data` directory, as well as stub application data.
+
+If, for any reason, any of the underlying data needs to change, we
+can run the following command to update the Wiremock mappings:
+
+```bash
+script/generate_mappings
+```

--- a/data/applicationData.json
+++ b/data/applicationData.json
@@ -1,0 +1,379 @@
+{
+  "basic-information": {
+    "sentence-type": {
+      "sentenceType": "bailPlacement"
+    },
+    "situation": {
+      "situation": "bailSentence"
+    },
+    "release-date": {
+      "releaseDate-year": "2022",
+      "releaseDate-month": "11",
+      "releaseDate-day": "14",
+      "releaseDate": "2022-11-14",
+      "knowReleaseDate": "yes"
+    },
+    "placement-date": {
+      "startDateSameAsReleaseDate": "yes"
+    },
+    "placement-purpose": {
+      "placementPurposes": ["drugAlcoholMonitoring", "otherReason"],
+      "otherReason": "Reason"
+    }
+  },
+  "type-of-ap": {
+    "ap-type": {
+      "type": "standard"
+    }
+  },
+  "oasys-import": {
+    "optional-oasys-sections": {
+      "needsLinkedToReoffending": [
+        { "section": 1, "name": "accommodation", "linkedToHarm": false, "linkedToReOffending": true },
+        { "section": 2, "name": "relationships", "linkedToHarm": false, "linkedToReOffending": true }
+      ],
+      "otherNeeds": [
+        {
+          "section": 3,
+          "name": "emotional",
+          "linkedToHarm": false,
+          "linkedToReOffending": false
+        },
+        {
+          "section": 4,
+          "name": "thinking",
+          "linkedToHarm": false,
+          "linkedToReOffending": false
+        }
+      ]
+    },
+    "rosh-summary": {
+      "roshAnswers": [
+        "Some answer for the first RoSH question. With an extra comment 1",
+        "Some answer for the second RoSH question. With an extra comment 2",
+        "Some answer for the third RoSH question. With an extra comment 3"
+      ],
+      "roshSummaries": [
+        {
+          "questionNumber": "1",
+          "label": "The first RoSH question",
+          "answer": "Some answer for the first RoSH question"
+        },
+        {
+          "questionNumber": "2",
+          "label": "The second RoSH question",
+          "answer": "Some answer for the second RoSH question"
+        },
+        {
+          "questionNumber": "3",
+          "label": "The third RoSH question",
+          "answer": "Some answer for the third RoSH question"
+        }
+      ]
+    },
+    "offence-details": {
+      "offenceDetailsAnswers": [
+        "Some answer for the first offence details question. With an extra comment 1",
+        "Some answer for the second offence details question. With an extra comment 2",
+        "Some answer for the third offence details question. With an extra comment 3"
+      ],
+      "offenceDetailsSummaries": [
+        {
+          "questionNumber": "1",
+          "label": "The first offence details question",
+          "answer": "Some answer for the first offence details question"
+        },
+        {
+          "questionNumber": "2",
+          "label": "The second offence details question",
+          "answer": "Some answer for the second offence details question"
+        },
+        {
+          "questionNumber": "3",
+          "label": "The third offence details question",
+          "answer": "Some answer for the third offence details question"
+        }
+      ]
+    },
+    "supporting-information": {
+      "supportingInformationAnswers": [
+        "Some answer for the first supporting information question. With an extra comment 1",
+        "Some answer for the second supporting information question. With an extra comment 2",
+        "Some answer for the third supporting information question. With an extra comment 3"
+      ],
+      "supportingInformationSummaries": [
+        {
+          "questionNumber": "1",
+          "label": "The first supporting information question",
+          "answer": "Some answer for the first supporting information question"
+        },
+        {
+          "questionNumber": "2",
+          "label": "The second supporting information question",
+          "answer": "Some answer for the second supporting information question"
+        },
+        {
+          "questionNumber": "3",
+          "label": "The third supporting information question",
+          "answer": "Some answer for the third supporting information question"
+        }
+      ]
+    },
+    "risk-management-plan": {
+      "riskManagementAnswers": [
+        "Some answer for the first risk management question. With an extra comment 1",
+        "Some answer for the second risk management question. With an extra comment 2",
+        "Some answer for the third risk management question. With an extra comment 3"
+      ],
+      "riskManagementSummaries": [
+        {
+          "questionNumber": "1",
+          "label": "The first risk management question",
+          "answer": "Some answer for the first risk management question"
+        },
+        {
+          "questionNumber": "2",
+          "label": "The second risk management question",
+          "answer": "Some answer for the second risk management question"
+        },
+        {
+          "questionNumber": "3",
+          "label": "The third risk management question",
+          "answer": "Some answer for the third risk management question"
+        }
+      ]
+    },
+    "risk-to-self": {
+      "riskToSelfAnswers": [
+        "Some answer for the first risk to self question. With an extra comment 1",
+        "Some answer for the second risk to self question. With an extra comment 2",
+        "Some answer for the third risk to self question. With an extra comment 3"
+      ],
+      "riskToSelfSummaries": [
+        {
+          "questionNumber": "1",
+          "label": "The first risk to self question",
+          "answer": "Some answer for the first risk to self question"
+        },
+        {
+          "questionNumber": "2",
+          "label": "The second risk to self question",
+          "answer": "Some answer for the second risk to self question"
+        },
+        {
+          "questionNumber": "3",
+          "label": "The third risk to self question",
+          "answer": "Some answer for the third risk to self question"
+        }
+      ]
+    }
+  },
+  "risk-management-features": {
+    "risk-management-features": {
+      "manageRiskDetails": "est vero nesciunt",
+      "additionalFeaturesDetails": "deleniti enim necessitatibus"
+    },
+    "convicted-offences": {
+      "response": "yes"
+    },
+    "type-of-convicted-offence": {
+      "offenceConvictions": ["arson", "sexualOffence", "hateCrimes", "childNonSexualOffence"]
+    },
+    "date-of-offence": {
+      "arsonOffence": ["current"],
+      "hateCrime": ["previous"],
+      "inPersonSexualOffence": ["current", "previous"]
+    },
+    "rehabilitative-interventions": {
+      "rehabilitativeInterventions": [
+        "accommodation",
+        "drugsAndAlcohol",
+        "childrenAndFamilies",
+        "health",
+        "educationTrainingAndEmployment",
+        "financeBenefitsAndDebt",
+        "attitudesAndBehaviour",
+        "abuse",
+        "other"
+      ],
+      "otherIntervention": "Another"
+    }
+  },
+  "prison-information": {
+    "case-notes": {
+      "caseNoteIds": ["a30173ca-061f-42c9-a1a2-28c70b282d3f", "4a477187-b77f-4fcc-a919-43a6633ee868"],
+      "selectedCaseNotes": [
+        {
+          "authorName": "Denise Collins",
+          "id": "a30173ca-061f-42c9-a1a2-28c70b282d3f",
+          "createdAt": "2022-11-10",
+          "occurredAt": "2022-10-19",
+          "sensitive": false,
+          "subType": "Ressettlement",
+          "type": "Social Care",
+          "note": "Note 1"
+        },
+        {
+          "authorName": "Leticia Mann",
+          "id": "4a477187-b77f-4fcc-a919-43a6633ee868",
+          "createdAt": "2022-07-24",
+          "occurredAt": "2022-09-22",
+          "sensitive": true,
+          "subType": "Quality Work",
+          "type": "General",
+          "note": "Note 2"
+        }
+      ],
+      "moreDetail": "some details",
+      "adjudications": [
+        {
+          "id": 69927,
+          "reportedAt": "2022-10-09",
+          "establishment": "Hawthorne",
+          "offenceDescription": "Nam vel nisi fugiat veniam possimus omnis.",
+          "hearingHeld": false,
+          "finding": "NOT_PROVED"
+        },
+        {
+          "id": 39963,
+          "reportedAt": "2022-07-10",
+          "establishment": "Oklahoma City",
+          "offenceDescription": "Illum maxime enim explicabo soluta sequi voluptas.",
+          "hearingHeld": true,
+          "finding": "PROVED"
+        },
+        {
+          "id": 77431,
+          "reportedAt": "2022-05-30",
+          "establishment": "Jurupa Valley",
+          "offenceDescription": "Quis porro nemo voluptates doloribus atque quis provident iure.",
+          "hearingHeld": false,
+          "finding": "PROVED"
+        }
+      ]
+    }
+  },
+  "location-factors": {
+    "describe-location-factors": {
+      "postcodeArea": "SW1",
+      "positiveFactors": "Some positive factors",
+      "restrictions": "yes",
+      "restrictionDetail": "Restrictions go here",
+      "alternativeRadiusAccepted": "yes",
+      "alternativeRadius": "70",
+      "differentPDU": "no"
+    },
+    "pdu-transfer": {
+      "transferStatus": "yes",
+      "probationPractitioner": "Probation Practicioner"
+    }
+  },
+  "access-and-healthcare": {
+    "access-needs": {
+      "additionalNeeds": ["mobility", "learningDisability", "neurodivergentConditions"],
+      "religiousOrCulturalNeeds": "yes",
+      "religiousOrCulturalNeedsDetails": "sunt at minus",
+      "needsInterpreter": "yes",
+      "interpreterLanguage": "beatae eligendi explicabo",
+      "careActAssessmentCompleted": "yes"
+    },
+    "access-needs-mobility": {
+      "needsWheelchair": "yes",
+      "mobilityNeeds": "laboriosam",
+      "visualImpairment": "exercitationem"
+    },
+    "covid": {
+      "fullyVaccinated": "yes",
+      "highRisk": "yes",
+      "additionalCovidInfo": "additional info"
+    }
+  },
+  "further-considerations": {
+    "room-sharing": {
+      "riskToStaff": "no",
+      "riskToStaffDetail": "",
+      "riskToOthers": "no",
+      "riskToOthersDetail": "",
+      "sharingConcerns": "yes",
+      "sharingConcernsDetail": "Some details here",
+      "traumaConcerns": "no",
+      "traumaConcernsDetail": "",
+      "sharingBenefits": "no",
+      "sharingBenefitsDetail": ""
+    },
+    "vulnerability": {
+      "exploitable": "no",
+      "exploitableDetail": "",
+      "exploitOthers": "yes",
+      "exploitOthersDetail": "Some details here"
+    },
+    "previous-placements": {
+      "previousPlacement": "yes",
+      "previousPlacementDetail": "Some details here"
+    },
+    "complex-case-board": {
+      "complexCaseBoard": "yes",
+      "complexCaseBoardDetail": "Some details here"
+    },
+    "catering": {
+      "catering": "yes",
+      "cateringDetail": "Some details here"
+    },
+    "arson": {
+      "arson": "yes",
+      "arsonDetail": "Some details here"
+    }
+  },
+  "move-on": {
+    "placement-duration": {
+      "duration": "10",
+      "durationDetail": "Some more information"
+    },
+    "relocation-region": {
+      "postcodeArea": "XX1"
+    },
+    "plans-in-place": {
+      "arePlansInPlace": "yes"
+    },
+    "type-of-accommodation": {
+      "accommodationType": "foreignNational",
+      "otherAccommodationType": ""
+    },
+    "foreign-national": {
+      "response": "yes",
+      "date-year": "2015",
+      "date-month": "1",
+      "date-day": "1",
+      "date": "2015-01-01"
+    }
+  },
+  "attach-required-documents": {
+    "attach-documents": {
+      "selectedDocuments": [
+        {
+          "id": "aeb43e06-a4a1-460f-9acf-e2495de84604",
+          "level": "Offender",
+          "fileName": "Random offender document1.pdf",
+          "createdAt": "2019-09-10T00:00:00Z",
+          "typeCode": "OFFENDER_DOCUMENT",
+          "typeDescription": "Offender related",
+          "description": "Some Description 1"
+        },
+        {
+          "id": "5f8a2288-0a17-4e45-afd5-5e57794a7b53",
+          "level": "Conviction",
+          "fileName": "national.asm",
+          "createdAt": "2022-09-13",
+          "typeCode": "serenade",
+          "typeDescription": "porter",
+          "description": "Some Description 2"
+        }
+      ]
+    }
+  },
+  "check-your-answers": {
+    "review": {
+      "reviewed": "1"
+    }
+  }
+}

--- a/data/applicationDocument.json
+++ b/data/applicationDocument.json
@@ -1,0 +1,169 @@
+{
+  "basic-information":[
+     {
+        "Which of the following best describes the sentence type?":"Standard determinate custody"
+     },
+     {
+        "What type of release will the application support?":"Release on Temporary License (ROTL)"
+     },
+     {
+        "Do you know Justyn Flatley’s release date?":"Yes",
+        "Release Date":"Saturday 1 April 2023"
+     },
+     {
+        "Is Saturday 1 April 2023 the date you want the placement to start?":"Yes"
+     },
+     {
+        "What is the purpose of the AP placement?":"Prevent contact, Help individual readjust to life outside custody"
+     }
+  ],
+  "type-of-ap":[
+     {
+        "Which type of AP does Justyn Flatley require?":"Standard"
+     }
+  ],
+  "oasys-import":[
+     {
+        "Needs linked to reoffending":"9. Alcohol",
+        "Needs not linked to risk of serious harm or reoffending":"5. Finance, 11. Thinking and behavioural"
+     },
+     {
+        "R10.1":"[R10.1] IN CUSTODY\r\n \r\n KNOWN ADULTS:\r\n Such as Ms Elaine Underhill and any of the victims of the index offence if they are placed close to Mr Smith cell.\r\n \r\n CHILDREN:\r\n Simon Smith, Roger Smith, Lindy Smith",
+        "R10.2":"[R10.2] IN CUSTODY:\r\n \r\n KNOWN ADULTS:\r\n Intimidation, threats of violence, use of weapons or boiling water, physical education and violent assault, long term psychological impact as a result of Mr Smith violent behaviour. This harm may be cause in the course of physical altercation due to seeking revenge or holding grudges...",
+        "R10.3":"[R10.3] STATIC RISK FACTORS:\r\n \r\n Mr Smith gender - At the time of the offence, Mr Smith was 35 years old and considered to be in the higher risk group.\r\n \r\n STABLE DYNAMIC RISK FACTORS:\r\n Thinking and behaviour - limited ability to manage mood or emotions poor impulse control. Mr Smith demonstrated cognitive deficit in committing the index offences and this still remains a concern...",
+        "R10.4":"[R10.4] CIRCUMSTANCES:\r\n A lack of stable accommodation\r\n unemployment\r\n non constructive use of time\r\n breakdown of family support\r\n being unable to access benefits\r\n \r\n UNDERLYING FACTORS:\r\n pro criminal attitudes supporting commission of crime...",
+        "R10.5":"[R10.5] Engage with Mental Health Services in prison and in the community.\r\n Maintain emotional stability.\r\n Abstain from alcohol.\r\n Abstain from illegal drugs.\r\n Regular testing for alcohol and drug use, in prison and on Licence.\r\n Maintain stable accommodation..."
+     },
+     {
+        "2.1":"",
+        "2.4.1":"",
+        "2.4.2":"",
+        "2.12":"",
+        "2.5":"",
+        "2.8.3":"",
+        "2.98":""
+     },
+     {
+        "3.9":"[3.9] Mr Smith told me that he was renting a room in a shared house, prior to his current remand...",
+        "4.9":"[4.9] He said that he has since learnt to read and write during periods of custody and an initial assessment of his...",
+        "5.9":"[5.9] Mr Smith was in receipt of Job Seekers Allowance prior to his current remand in custody...",
+        "9.9":"[9.9] Mr Smith told me that he rarely consumes alcohol and has not had any problems associated with excessive drinking in years...",
+        "11.9":"[11.9] The circumstances of the current offence suggest that Mr Smith acted ..."
+     },
+     {
+        "RM28":"[RM28] Mr Smith is currently on remand awaiting sentence",
+        "RM35":"[RM35] Placeholder content for additional comments",
+        "RM34":"[RM34] Discuss any concerns with line manager/SPO Increase frequency of reporting Bring forward MAPPA/Consider Level 2 MAPPA professionals meetings  considered if MAPPA not applicable. Consider referral to Approved Premises Consider motivational interviewing/engagement officer.  Joint interview with police OM or other relevant agencies? To raise concerns Referral to substance misues worker for additional support. Warning letters to be employed Recall/Breach if risk not manageable.",
+        "RM33":"[RM33] Undertake sentence planning with OS within 8 or 16 weeks of sentence carats - continue to work with Mr Smith and refer for relevant programmes during any prison sentence imposed. DIP supervise DRR is imposed or provide support post release if conditions/requirements to manage the specific risks.",
+        "RM32":"[RM32] Requires referral to community drug DIP upon  release. To link in with employment/training resources such as College and ETEO. Completion of victim empathy module via 1-1 supervision to build upon awareness of impact of offending.   Level setting to be undertaken by Senior Probation Officer and OMU. Multi Agency Public Protection Panel to be convened if level 2 either at start of supervision or 6 months prior to release",
+        "RM31":"[RM31] State they will have secure accommodation for Mr Smith  and partner on release, although she too is subject to a DRR at present. Supportive wider family.  Has completed previously Short Duration programme and attended one of the support sessions .  Engaged with CARATS in custody.  Complied with voluntary drug tests in custody. Some motivation to desist from alcohol/drug use in the future, this needs to be encouraged with use of community resources. Completed drug and heroin awareness programmes in custody.",
+        "RM30":"[RM30] Probation Officer, Education training and employment Officer, Prison Offender Supervisor",
+        "RM28.1":"[RM28.1] Currently on remand at HMP Wandsworth - Management of case under MAPPA - level not yet set."
+     },
+     {
+        "R8.1.1":"Review 06.10.21:\r\n \r\n         There have been numerous ACCTs opened since 2013 and every subsequent year he has been in custody.  In 2021...",
+        "R8.2.1":"Has told prison staff that he swallowed batteries on one occasion due to wanting..",
+        "R8.3.1":"Review 06.10.21:\r\n \r\n         A previous assessor opined that Mr Smith was displaying all the characteristics of someone..."
+     }
+  ],
+  "risk-management-features":[
+     {
+        "Describe why an AP placement is needed to manage the risk of Justyn Flatley":"Some words",
+        "Provide details of any additional measures that will be necessary for the management of risk":"Some words"
+     },
+     {
+        "Has Justyn Flatley ever been convicted of any arson offences, sexual offences, hate crimes or non-sexual offences against children?":"No"
+     },
+     {
+        "Which rehabilitative interventions will support the person''s Approved Premises (AP) placement?":"Drugs and alcohol, Children and families"
+     }
+  ],
+  "prison-information":[
+     {
+        "Selected prison case notes that support this application":[
+           "Array"
+        ],
+        "Adjudications":[
+           "Array"
+        ]
+     }
+  ],
+  "location-factors":[
+     {
+        "What is the preferred location for the AP placement?":"WS1",
+        "Give details of any positive factors for the person in this location.":"Some words",
+        "Are there any restrictions linked to placement location?":"No",
+        "If an AP Placement is not available in the persons preferred area, would a placement further away be considered?":"No",
+        "Is the person moving to a different area where they''ll be managed by a different probation delivery unit (PDU)?":"No"
+     },
+     {
+        "Have you agreed Justyn Flatley''s transfer/supervision with the receiving PDU?":"No, I still need to make arrangements"
+     }
+  ],
+  "access-and-healthcare":[
+     {
+        "Does Justyn Flatley have any of the following needs?":"Learning disability, hearing impairment",
+        "Does Justyn Flatley have any religious or cultural needs?":"No",
+        "Details of religious or cultural needs":"",
+        "Does Justyn Flatley need an interpreter?":"No",
+        "Has a care act assessment been completed?":"No"
+     },
+     {
+        "Has Justyn Flatley been fully vaccinated for COVID-19?":"No",
+        "Is Justyn Flatley at a higher risk from COVID-19?":"No"
+     }
+  ],
+  "further-considerations":[
+     {
+        "Is there any evidence that the person may pose a risk to AP staff?":"No",
+        "Is there any evidence that the person may pose a risk to other AP residents?":"No",
+        "Do you have any concerns about the person sharing a bedroom?":"No",
+        "Is there any evidence of previous trauma or significant event in the persons history which would indicate that room share may not be suitable?":"No",
+        "Is there potential for the person to benefit from a room share?":"No"
+     },
+     {
+        "Are you aware that Justyn Flatley is vulnerable to exploitation from others?":"No",
+        "Is there any evidence or expectation that Justyn Flatley may groom, radicalise or exploit others?":"No"
+     },
+     {
+        "Has Justyn Flatley stayed or been offered a placement in an AP before?":"No"
+     },
+     {
+        "Does Justyn Flatley''s gender identity require a complex case board to review their application?":"No"
+     },
+     {
+        "Do you have any concerns about Justyn Flatley catering for themselves?":"No"
+     },
+     {
+        "Does Justyn Flatley need a specialist arson room?":"No"
+     }
+  ],
+  "move-on":[
+     {
+        "What duration of placement do you recommend?":"11 weeks",
+        "Provide any additional information":"Some words"
+     },
+     {
+        "Where is Justyn Flatley most likely to live when they move on from the AP?":"WS13"
+     },
+     {
+        "Are move on arrangements already in place for when the person leaves the AP?":"No"
+     },
+     {
+        "What type of accommodation will Justyn Flatley have when they leave the AP?":"Supported housing"
+     }
+  ],
+  "attach-required-documents":[
+     {
+        "PRE-CONS.pdf":"Previous convictions as of 01/09/2019",
+        "Personal circumstances.pdf.pdf":"Personal circumstance of AP - Medication in Posession  - Assessment started on 11/09/2019",
+        "NSIOffender.pdf":"Non Statutory Intervention for OPD Community Pathway on 16/10/2019",
+        "paroleParom1Report_04092019_122116_OMIC_A_X320741.pdf":"Parole Assessment Report at Berwyn (HMP) requested on 05/09/2019"
+     }
+  ],
+  "check-your-answers":[
+     {
+
+     }
+  ]
+}

--- a/data/offenders.json
+++ b/data/offenders.json
@@ -1,0 +1,682 @@
+[
+  {
+    "offenderId": "8484625583",
+    "firstName": "Tate",
+    "middleNames": [
+      "Kennedy"
+    ],
+    "surname": "Homenick",
+    "preferredName": "Demetris",
+    "dateOfBirth": "2022-05-01",
+    "gender": "Female",
+    "otherIds": {
+      "crn": "315VWWC",
+      "nomsNumber": "M59CS58",
+      "mostRecentPrisonerNumber": "ZQCBD"
+    },
+    "contactDetails": {},
+    "offenderProfile": {
+      "offenderLanguages": {},
+      "remandStatus": "Bail - Unconditional",
+      "previousConviction": {
+        "convictionDate": "2022-06-08T09:05:25.228Z",
+        "detail": {
+          "documentName": "PRE-CONS.pdf"
+        }
+      },
+      "disabilities": []
+    },
+    "softDeleted": false,
+    "currentDisposal": "1",
+    "partitionArea": "National Data",
+    "currentRestriction": false,
+    "currentExclusion": false,
+    "activeProbationManagedSentence": true
+  },
+  {
+    "offenderId": "9430466263",
+    "firstName": "Greta",
+    "middleNames": [
+      "Hayden"
+    ],
+    "surname": "Kshlerin",
+    "preferredName": "Leland",
+    "dateOfBirth": "2022-08-12",
+    "gender": "Female",
+    "otherIds": {
+      "crn": "4Y29R9P",
+      "nomsNumber": "XWU5JWQ",
+      "mostRecentPrisonerNumber": "9GJ67"
+    },
+    "contactDetails": {},
+    "offenderProfile": {
+      "offenderLanguages": {},
+      "remandStatus": "Bail - Unconditional",
+      "previousConviction": {
+        "convictionDate": "2022-10-24T12:45:11.170Z",
+        "detail": {
+          "documentName": "PRE-CONS.pdf"
+        }
+      },
+      "disabilities": []
+    },
+    "softDeleted": false,
+    "currentDisposal": "1",
+    "partitionArea": "National Data",
+    "currentRestriction": false,
+    "currentExclusion": false,
+    "activeProbationManagedSentence": true
+  },
+  {
+    "offenderId": "7196202991",
+    "firstName": "Rosalee",
+    "middleNames": [
+      "Riley"
+    ],
+    "surname": "Hackett",
+    "preferredName": "Cecil",
+    "dateOfBirth": "2022-02-23",
+    "gender": "Female",
+    "otherIds": {
+      "crn": "4ZUIHFX",
+      "nomsNumber": "5A5C8WL",
+      "mostRecentPrisonerNumber": "51GVD"
+    },
+    "contactDetails": {},
+    "offenderProfile": {
+      "offenderLanguages": {},
+      "remandStatus": "Bail - Unconditional",
+      "previousConviction": {
+        "convictionDate": "2022-11-23T23:55:14.228Z",
+        "detail": {
+          "documentName": "PRE-CONS.pdf"
+        }
+      },
+      "disabilities": []
+    },
+    "softDeleted": false,
+    "currentDisposal": "1",
+    "partitionArea": "National Data",
+    "currentRestriction": false,
+    "currentExclusion": false,
+    "activeProbationManagedSentence": true
+  },
+  {
+    "offenderId": "1755132216",
+    "firstName": "Tristin",
+    "middleNames": [
+      "River"
+    ],
+    "surname": "Satterfield",
+    "preferredName": "Malvina",
+    "dateOfBirth": "2022-04-17",
+    "gender": "Prefer not to say",
+    "otherIds": {
+      "crn": "52W7TQG",
+      "nomsNumber": "5HBWEG1",
+      "mostRecentPrisonerNumber": "D9TYS"
+    },
+    "contactDetails": {},
+    "offenderProfile": {
+      "offenderLanguages": {},
+      "remandStatus": "Bail - Unconditional",
+      "previousConviction": {
+        "convictionDate": "2022-07-30T04:10:12.375Z",
+        "detail": {
+          "documentName": "PRE-CONS.pdf"
+        }
+      },
+      "disabilities": []
+    },
+    "softDeleted": false,
+    "currentDisposal": "1",
+    "partitionArea": "National Data",
+    "currentRestriction": false,
+    "currentExclusion": false,
+    "activeProbationManagedSentence": true
+  },
+  {
+    "offenderId": "8465094569",
+    "firstName": "Berneice",
+    "middleNames": [
+      "London"
+    ],
+    "surname": "Cassin",
+    "preferredName": "Ana",
+    "dateOfBirth": "2022-03-14",
+    "gender": "Other",
+    "otherIds": {
+      "crn": "5EC66UT",
+      "nomsNumber": "530X5EC",
+      "mostRecentPrisonerNumber": "5WKFA"
+    },
+    "contactDetails": {},
+    "offenderProfile": {
+      "offenderLanguages": {},
+      "remandStatus": "Bail - Unconditional",
+      "previousConviction": {
+        "convictionDate": "2022-05-11T14:03:06.989Z",
+        "detail": {
+          "documentName": "PRE-CONS.pdf"
+        }
+      },
+      "disabilities": []
+    },
+    "softDeleted": false,
+    "currentDisposal": "1",
+    "partitionArea": "National Data",
+    "currentRestriction": false,
+    "currentExclusion": false,
+    "activeProbationManagedSentence": true
+  },
+  {
+    "offenderId": "9110934330",
+    "firstName": "Tiffany",
+    "middleNames": [
+      "Rory"
+    ],
+    "surname": "Kovacek",
+    "preferredName": "Javonte",
+    "dateOfBirth": "2022-10-01",
+    "gender": "Other",
+    "otherIds": {
+      "crn": "8LO3HSH",
+      "nomsNumber": "JD5CLIA",
+      "mostRecentPrisonerNumber": "HCCKP"
+    },
+    "contactDetails": {},
+    "offenderProfile": {
+      "offenderLanguages": {},
+      "remandStatus": "Bail - Unconditional",
+      "previousConviction": {
+        "convictionDate": "2021-12-27T06:00:00.880Z",
+        "detail": {
+          "documentName": "PRE-CONS.pdf"
+        }
+      },
+      "disabilities": []
+    },
+    "softDeleted": false,
+    "currentDisposal": "1",
+    "partitionArea": "National Data",
+    "currentRestriction": false,
+    "currentExclusion": false,
+    "activeProbationManagedSentence": true
+  },
+  {
+    "offenderId": "9731712146",
+    "firstName": "Caleigh",
+    "middleNames": [
+      "North"
+    ],
+    "surname": "O'Hara",
+    "preferredName": "Cora",
+    "dateOfBirth": "2022-02-01",
+    "gender": "Male",
+    "otherIds": {
+      "crn": "BWEFOI7",
+      "nomsNumber": "SX9UI94",
+      "mostRecentPrisonerNumber": "NMHSA"
+    },
+    "contactDetails": {},
+    "offenderProfile": {
+      "offenderLanguages": {},
+      "remandStatus": "Bail - Unconditional",
+      "previousConviction": {
+        "convictionDate": "2022-09-24T06:49:33.588Z",
+        "detail": {
+          "documentName": "PRE-CONS.pdf"
+        }
+      },
+      "disabilities": []
+    },
+    "softDeleted": false,
+    "currentDisposal": "1",
+    "partitionArea": "National Data",
+    "currentRestriction": false,
+    "currentExclusion": false,
+    "activeProbationManagedSentence": true
+  },
+  {
+    "offenderId": "6771554086",
+    "firstName": "Mattie",
+    "middleNames": [
+      "Reagan"
+    ],
+    "surname": "Goldner",
+    "preferredName": "Kaleigh",
+    "dateOfBirth": "2022-04-27",
+    "gender": "Female",
+    "otherIds": {
+      "crn": "GSR1T2F",
+      "nomsNumber": "KXTJQEF",
+      "mostRecentPrisonerNumber": "EQ6J0"
+    },
+    "contactDetails": {},
+    "offenderProfile": {
+      "offenderLanguages": {},
+      "remandStatus": "Bail - Unconditional",
+      "previousConviction": {
+        "convictionDate": "2022-09-24T14:07:16.777Z",
+        "detail": {
+          "documentName": "PRE-CONS.pdf"
+        }
+      },
+      "disabilities": []
+    },
+    "softDeleted": false,
+    "currentDisposal": "1",
+    "partitionArea": "National Data",
+    "currentRestriction": false,
+    "currentExclusion": false,
+    "activeProbationManagedSentence": true
+  },
+  {
+    "offenderId": "7182517629",
+    "firstName": "Nakia",
+    "middleNames": [
+      "Skyler"
+    ],
+    "surname": "Prosacco",
+    "preferredName": "Ana",
+    "dateOfBirth": "2022-04-22",
+    "gender": "Male",
+    "otherIds": {
+      "crn": "HRV83TE",
+      "nomsNumber": "N1RRJZU",
+      "mostRecentPrisonerNumber": "MY5Q3"
+    },
+    "contactDetails": {},
+    "offenderProfile": {
+      "offenderLanguages": {},
+      "remandStatus": "Bail - Unconditional",
+      "previousConviction": {
+        "convictionDate": "2022-03-20T11:57:34.935Z",
+        "detail": {
+          "documentName": "PRE-CONS.pdf"
+        }
+      },
+      "disabilities": []
+    },
+    "softDeleted": false,
+    "currentDisposal": "1",
+    "partitionArea": "National Data",
+    "currentRestriction": false,
+    "currentExclusion": false,
+    "activeProbationManagedSentence": true
+  },
+  {
+    "offenderId": "6370998601",
+    "firstName": "Justine",
+    "middleNames": [
+      "Shawn"
+    ],
+    "surname": "Bernhard",
+    "preferredName": "Jarrett",
+    "dateOfBirth": "2022-06-26",
+    "gender": "Prefer not to say",
+    "otherIds": {
+      "crn": "HTVI42B",
+      "nomsNumber": "6X1DNW1",
+      "mostRecentPrisonerNumber": "L8EZ0"
+    },
+    "contactDetails": {},
+    "offenderProfile": {
+      "offenderLanguages": {},
+      "remandStatus": "Bail - Unconditional",
+      "previousConviction": {
+        "convictionDate": "2022-11-04T04:59:56.179Z",
+        "detail": {
+          "documentName": "PRE-CONS.pdf"
+        }
+      },
+      "disabilities": []
+    },
+    "softDeleted": false,
+    "currentDisposal": "1",
+    "partitionArea": "National Data",
+    "currentRestriction": false,
+    "currentExclusion": false,
+    "activeProbationManagedSentence": true
+  },
+  {
+    "offenderId": "4080765472",
+    "firstName": "Mariam",
+    "middleNames": [
+      "Greer"
+    ],
+    "surname": "Rutherford",
+    "preferredName": "Kelvin",
+    "dateOfBirth": "2022-08-13",
+    "gender": "Female",
+    "otherIds": {
+      "crn": "HUN3BN0",
+      "nomsNumber": "YCSW8BD",
+      "mostRecentPrisonerNumber": "Q8UTQ"
+    },
+    "contactDetails": {},
+    "offenderProfile": {
+      "offenderLanguages": {},
+      "remandStatus": "Bail - Unconditional",
+      "previousConviction": {
+        "convictionDate": "2022-11-05T01:14:06.120Z",
+        "detail": {
+          "documentName": "PRE-CONS.pdf"
+        }
+      },
+      "disabilities": []
+    },
+    "softDeleted": false,
+    "currentDisposal": "1",
+    "partitionArea": "National Data",
+    "currentRestriction": false,
+    "currentExclusion": false,
+    "activeProbationManagedSentence": true
+  },
+  {
+    "offenderId": "3765661115",
+    "firstName": "Stacey",
+    "middleNames": [
+      "Reagan"
+    ],
+    "surname": "Bode",
+    "preferredName": "Alex",
+    "dateOfBirth": "2022-11-30",
+    "gender": "Male",
+    "otherIds": {
+      "crn": "IHGHXYM",
+      "nomsNumber": "KWAPTC7",
+      "mostRecentPrisonerNumber": "MLJTS"
+    },
+    "contactDetails": {},
+    "offenderProfile": {
+      "offenderLanguages": {},
+      "remandStatus": "Bail - Unconditional",
+      "previousConviction": {
+        "convictionDate": "2022-06-02T15:09:38.508Z",
+        "detail": {
+          "documentName": "PRE-CONS.pdf"
+        }
+      },
+      "disabilities": []
+    },
+    "softDeleted": false,
+    "currentDisposal": "1",
+    "partitionArea": "National Data",
+    "currentRestriction": false,
+    "currentExclusion": false,
+    "activeProbationManagedSentence": true
+  },
+  {
+    "offenderId": "3590473911",
+    "firstName": "Robbie",
+    "middleNames": [
+      "Leslie"
+    ],
+    "surname": "O'Hara",
+    "preferredName": "Elsie",
+    "dateOfBirth": "2022-02-24",
+    "gender": "Male",
+    "otherIds": {
+      "crn": "JCRH9V5",
+      "nomsNumber": "VTDINBA",
+      "mostRecentPrisonerNumber": "JT2HR"
+    },
+    "contactDetails": {},
+    "offenderProfile": {
+      "offenderLanguages": {},
+      "remandStatus": "Bail - Unconditional",
+      "previousConviction": {
+        "convictionDate": "2022-10-27T23:49:39.407Z",
+        "detail": {
+          "documentName": "PRE-CONS.pdf"
+        }
+      },
+      "disabilities": []
+    },
+    "softDeleted": false,
+    "currentDisposal": "1",
+    "partitionArea": "National Data",
+    "currentRestriction": false,
+    "currentExclusion": false,
+    "activeProbationManagedSentence": true
+  },
+  {
+    "offenderId": "6449450552",
+    "firstName": "Christa",
+    "middleNames": [
+      "Jordan"
+    ],
+    "surname": "Ledner",
+    "preferredName": "Gabriella",
+    "dateOfBirth": "2022-12-10",
+    "gender": "Other",
+    "otherIds": {
+      "crn": "N6OUTAY",
+      "nomsNumber": "HIR0PIN",
+      "mostRecentPrisonerNumber": "IKRSD"
+    },
+    "contactDetails": {},
+    "offenderProfile": {
+      "offenderLanguages": {},
+      "remandStatus": "Bail - Unconditional",
+      "previousConviction": {
+        "convictionDate": "2022-08-15T02:18:50.878Z",
+        "detail": {
+          "documentName": "PRE-CONS.pdf"
+        }
+      },
+      "disabilities": []
+    },
+    "softDeleted": false,
+    "currentDisposal": "1",
+    "partitionArea": "National Data",
+    "currentRestriction": false,
+    "currentExclusion": false,
+    "activeProbationManagedSentence": true
+  },
+  {
+    "offenderId": "2332576662",
+    "firstName": "Justyn",
+    "middleNames": [
+      "Phoenix"
+    ],
+    "surname": "Flatley",
+    "preferredName": "Dario",
+    "dateOfBirth": "2022-07-06",
+    "gender": "Male",
+    "otherIds": {
+      "crn": "PI251LM",
+      "nomsNumber": "QGH3OL6",
+      "mostRecentPrisonerNumber": "YBTVR"
+    },
+    "contactDetails": {},
+    "offenderProfile": {
+      "offenderLanguages": {},
+      "remandStatus": "Bail - Unconditional",
+      "previousConviction": {
+        "convictionDate": "2022-04-23T08:09:21.882Z",
+        "detail": {
+          "documentName": "PRE-CONS.pdf"
+        }
+      },
+      "disabilities": []
+    },
+    "softDeleted": false,
+    "currentDisposal": "1",
+    "partitionArea": "National Data",
+    "currentRestriction": false,
+    "currentExclusion": false,
+    "activeProbationManagedSentence": true
+  },
+  {
+    "offenderId": "4428155372",
+    "firstName": "Geovanny",
+    "middleNames": [
+      "Bailey"
+    ],
+    "surname": "Gleichner",
+    "preferredName": "Frieda",
+    "dateOfBirth": "2022-11-26",
+    "gender": "Male",
+    "otherIds": {
+      "crn": "PR5E5Y2",
+      "nomsNumber": "M9XWJ1S",
+      "mostRecentPrisonerNumber": "KGSCJ"
+    },
+    "contactDetails": {},
+    "offenderProfile": {
+      "offenderLanguages": {},
+      "remandStatus": "Bail - Unconditional",
+      "previousConviction": {
+        "convictionDate": "2022-11-03T23:43:35.926Z",
+        "detail": {
+          "documentName": "PRE-CONS.pdf"
+        }
+      },
+      "disabilities": []
+    },
+    "softDeleted": false,
+    "currentDisposal": "1",
+    "partitionArea": "National Data",
+    "currentRestriction": false,
+    "currentExclusion": false,
+    "activeProbationManagedSentence": true
+  },
+  {
+    "offenderId": "1836247825",
+    "firstName": "Kaylee",
+    "middleNames": [
+      "Drew"
+    ],
+    "surname": "Frami",
+    "preferredName": "Delbert",
+    "dateOfBirth": "2022-11-21",
+    "gender": "Prefer not to say",
+    "otherIds": {
+      "crn": "QA93YYK",
+      "nomsNumber": "YX2YNT2",
+      "mostRecentPrisonerNumber": "8GO1M"
+    },
+    "contactDetails": {},
+    "offenderProfile": {
+      "offenderLanguages": {},
+      "remandStatus": "Bail - Unconditional",
+      "previousConviction": {
+        "convictionDate": "2022-09-24T03:23:51.552Z",
+        "detail": {
+          "documentName": "PRE-CONS.pdf"
+        }
+      },
+      "disabilities": []
+    },
+    "softDeleted": false,
+    "currentDisposal": "1",
+    "partitionArea": "National Data",
+    "currentRestriction": false,
+    "currentExclusion": false,
+    "activeProbationManagedSentence": true
+  },
+  {
+    "offenderId": "6957310125",
+    "firstName": "Ashton",
+    "middleNames": [
+      "Cameron"
+    ],
+    "surname": "Turner",
+    "preferredName": "Louisa",
+    "dateOfBirth": "2022-07-26",
+    "gender": "Prefer not to say",
+    "otherIds": {
+      "crn": "XCMSG3I",
+      "nomsNumber": "NYVS303",
+      "mostRecentPrisonerNumber": "YYSYW"
+    },
+    "contactDetails": {},
+    "offenderProfile": {
+      "offenderLanguages": {},
+      "remandStatus": "Bail - Unconditional",
+      "previousConviction": {
+        "convictionDate": "2022-10-28T14:55:57.766Z",
+        "detail": {
+          "documentName": "PRE-CONS.pdf"
+        }
+      },
+      "disabilities": []
+    },
+    "softDeleted": false,
+    "currentDisposal": "1",
+    "partitionArea": "National Data",
+    "currentRestriction": false,
+    "currentExclusion": false,
+    "activeProbationManagedSentence": true
+  },
+  {
+    "offenderId": "2954218885",
+    "firstName": "Nyah",
+    "middleNames": [
+      "Kai"
+    ],
+    "surname": "Gutmann",
+    "preferredName": "Marcus",
+    "dateOfBirth": "2022-11-13",
+    "gender": "Prefer not to say",
+    "otherIds": {
+      "crn": "YRPARSH",
+      "nomsNumber": "HBVE0LJ",
+      "mostRecentPrisonerNumber": "NT932"
+    },
+    "contactDetails": {},
+    "offenderProfile": {
+      "offenderLanguages": {},
+      "remandStatus": "Bail - Unconditional",
+      "previousConviction": {
+        "convictionDate": "2022-04-06T20:29:56.270Z",
+        "detail": {
+          "documentName": "PRE-CONS.pdf"
+        }
+      },
+      "disabilities": []
+    },
+    "softDeleted": false,
+    "currentDisposal": "1",
+    "partitionArea": "National Data",
+    "currentRestriction": false,
+    "currentExclusion": false,
+    "activeProbationManagedSentence": true
+  },
+  {
+    "offenderId": "6814869515",
+    "firstName": "Rozella",
+    "middleNames": [
+      "Riley"
+    ],
+    "surname": "Kovacek",
+    "preferredName": "Eliseo",
+    "dateOfBirth": "2022-04-06",
+    "gender": "Male",
+    "otherIds": {
+      "crn": "Z33A1BU",
+      "nomsNumber": "6DO89QY",
+      "mostRecentPrisonerNumber": "XRYLE"
+    },
+    "contactDetails": {},
+    "offenderProfile": {
+      "offenderLanguages": {},
+      "remandStatus": "Bail - Unconditional",
+      "previousConviction": {
+        "convictionDate": "2022-02-14T15:07:22.474Z",
+        "detail": {
+          "documentName": "PRE-CONS.pdf"
+        }
+      },
+      "disabilities": []
+    },
+    "softDeleted": false,
+    "currentDisposal": "1",
+    "partitionArea": "National Data",
+    "currentRestriction": false,
+    "currentExclusion": false,
+    "activeProbationManagedSentence": true
+  }
+]

--- a/data/users.json
+++ b/data/users.json
@@ -1,0 +1,32 @@
+[
+  {
+    "id": "7a424213-3a0c-45b0-9a51-4977243c2b21",
+    "username": "AP_TEST_USER_1",
+    "name": "AP Test User 1",
+    "email": "stuart.harrison2+test1@digital.justice.gov.uk"
+  },
+  {
+    "id": "8a39870c-3a1f-4e05-ad45-a450e15b242d",
+    "username": "AP_TEST_USER_2",
+    "name": "AP Test User 2",
+    "email": "stuart.harrison2+test2@digital.justice.gov.uk"
+  },
+  {
+    "id": "68715a03-06af-49ee-bae5-039c824ab9af",
+    "username": "AP_TEST_USER_3",
+    "name": "AP Test User 3",
+    "email": "stuart.harrison2+test3@digital.justice.gov.uk"
+  },
+  {
+    "id": "6dcd2559-2d14-4feb-8faf-89ad30dfa765",
+    "username": "AP_TEST_USER_4",
+    "name": "AP Test User 4",
+    "email": "stuart.harrison2+test4@digital.justice.gov.uk"
+  },
+  {
+    "id": "531455f4-c76f-4943-b4eb-3c02d8fefa69",
+    "username": "AP_TEST_USER_5",
+    "name": "AP Test User 5",
+    "email": "stuart.harrison2+test5@digital.justice.gov.uk"
+  }
+]

--- a/mappings/CommunityAPI_GetPerson_315VWWC.json
+++ b/mappings/CommunityAPI_GetPerson_315VWWC.json
@@ -1,5 +1,4 @@
 {
-  "id": "14b701fe-677f-4dd4-87e9-d12ce86c40e1",
   "name": "community_api_getPerson_315VWWC",
   "request": {
     "url": "/secure/offenders/crn/315VWWC",

--- a/mappings/CommunityAPI_GetPerson_4Y29R9P.json
+++ b/mappings/CommunityAPI_GetPerson_4Y29R9P.json
@@ -1,5 +1,4 @@
 {
-  "id": "7298c040-06c6-46b3-b17c-1cef23c378cf",
   "name": "community_api_getPerson_4Y29R9P",
   "request": {
     "url": "/secure/offenders/crn/4Y29R9P",

--- a/mappings/CommunityAPI_GetPerson_4ZUIHFX.json
+++ b/mappings/CommunityAPI_GetPerson_4ZUIHFX.json
@@ -1,5 +1,4 @@
 {
-  "id": "9c61ed29-6118-46a3-adfe-f820849a66cb",
   "name": "community_api_getPerson_4ZUIHFX",
   "request": {
     "url": "/secure/offenders/crn/4ZUIHFX",

--- a/mappings/CommunityAPI_GetPerson_52W7TQG.json
+++ b/mappings/CommunityAPI_GetPerson_52W7TQG.json
@@ -1,5 +1,4 @@
 {
-  "id": "3f438374-b3f3-4be8-b467-6458a33b9cda",
   "name": "community_api_getPerson_52W7TQG",
   "request": {
     "url": "/secure/offenders/crn/52W7TQG",

--- a/mappings/CommunityAPI_GetPerson_5EC66UT.json
+++ b/mappings/CommunityAPI_GetPerson_5EC66UT.json
@@ -1,5 +1,4 @@
 {
-  "id": "42ec48b4-0378-4e57-a67f-944a59ee4834",
   "name": "community_api_getPerson_5EC66UT",
   "request": {
     "url": "/secure/offenders/crn/5EC66UT",

--- a/mappings/CommunityAPI_GetPerson_8LO3HSH.json
+++ b/mappings/CommunityAPI_GetPerson_8LO3HSH.json
@@ -1,5 +1,4 @@
 {
-  "id": "f039657c-8494-49ce-9b12-136ebb76ec03",
   "name": "community_api_getPerson_8LO3HSH",
   "request": {
     "url": "/secure/offenders/crn/8LO3HSH",

--- a/mappings/CommunityAPI_GetPerson_BWEFOI7.json
+++ b/mappings/CommunityAPI_GetPerson_BWEFOI7.json
@@ -1,5 +1,4 @@
 {
-  "id": "731eb7cb-a863-45c2-a4f6-455f5b5357b5",
   "name": "community_api_getPerson_BWEFOI7",
   "request": {
     "url": "/secure/offenders/crn/BWEFOI7",

--- a/mappings/CommunityAPI_GetPerson_GSR1T2F.json
+++ b/mappings/CommunityAPI_GetPerson_GSR1T2F.json
@@ -1,5 +1,4 @@
 {
-  "id": "eb687e0f-3405-47af-b44f-ab49df45c2de",
   "name": "community_api_getPerson_GSR1T2F",
   "request": {
     "url": "/secure/offenders/crn/GSR1T2F",

--- a/mappings/CommunityAPI_GetPerson_HRV83TE.json
+++ b/mappings/CommunityAPI_GetPerson_HRV83TE.json
@@ -1,5 +1,4 @@
 {
-  "id": "bebfa8a5-4468-41c4-9e98-d0cd7ce151f9",
   "name": "community_api_getPerson_HRV83TE",
   "request": {
     "url": "/secure/offenders/crn/HRV83TE",

--- a/mappings/CommunityAPI_GetPerson_HTVI42B.json
+++ b/mappings/CommunityAPI_GetPerson_HTVI42B.json
@@ -1,5 +1,4 @@
 {
-  "id": "3fe63285-a2aa-4762-8223-a07c4c076788",
   "name": "community_api_getPerson_HTVI42B",
   "request": {
     "url": "/secure/offenders/crn/HTVI42B",

--- a/mappings/CommunityAPI_GetPerson_HUN3BN0.json
+++ b/mappings/CommunityAPI_GetPerson_HUN3BN0.json
@@ -1,5 +1,4 @@
 {
-  "id": "a6cac9fc-6c32-4f3f-9af4-6380030374ad",
   "name": "community_api_getPerson_HUN3BN0",
   "request": {
     "url": "/secure/offenders/crn/HUN3BN0",

--- a/mappings/CommunityAPI_GetPerson_IHGHXYM.json
+++ b/mappings/CommunityAPI_GetPerson_IHGHXYM.json
@@ -1,5 +1,4 @@
 {
-  "id": "2f8ff09b-435a-442a-a610-15fd6ba8950b",
   "name": "community_api_getPerson_IHGHXYM",
   "request": {
     "url": "/secure/offenders/crn/IHGHXYM",

--- a/mappings/CommunityAPI_GetPerson_JCRH9V5.json
+++ b/mappings/CommunityAPI_GetPerson_JCRH9V5.json
@@ -1,5 +1,4 @@
 {
-  "id": "f3ab9f47-29db-4dfd-856a-c46a033fd19d",
   "name": "community_api_getPerson_JCRH9V5",
   "request": {
     "url": "/secure/offenders/crn/JCRH9V5",

--- a/mappings/CommunityAPI_GetPerson_N6OUTAY.json
+++ b/mappings/CommunityAPI_GetPerson_N6OUTAY.json
@@ -1,5 +1,4 @@
 {
-  "id": "6979302d-22cf-49aa-b647-4862d28299ca",
   "name": "community_api_getPerson_N6OUTAY",
   "request": {
     "url": "/secure/offenders/crn/N6OUTAY",

--- a/mappings/CommunityAPI_GetPerson_PI251LM.json
+++ b/mappings/CommunityAPI_GetPerson_PI251LM.json
@@ -1,5 +1,4 @@
 {
-  "id": "d343dc2c-d5ea-402e-9959-9ef49dea14f2",
   "name": "community_api_getPerson_PI251LM",
   "request": {
     "url": "/secure/offenders/crn/PI251LM",

--- a/mappings/CommunityAPI_GetPerson_PR5E5Y2.json
+++ b/mappings/CommunityAPI_GetPerson_PR5E5Y2.json
@@ -1,5 +1,4 @@
 {
-  "id": "f4ff0df9-8885-45aa-a909-b8b0fa505bd0",
   "name": "community_api_getPerson_PR5E5Y2",
   "request": {
     "url": "/secure/offenders/crn/PR5E5Y2",

--- a/mappings/CommunityAPI_GetPerson_QA93YYK.json
+++ b/mappings/CommunityAPI_GetPerson_QA93YYK.json
@@ -1,5 +1,4 @@
 {
-  "id": "8e872899-b626-43f0-8ee9-4745e87b4c7a",
   "name": "community_api_getPerson_QA93YYK",
   "request": {
     "url": "/secure/offenders/crn/QA93YYK",

--- a/mappings/CommunityAPI_GetPerson_XCMSG3I.json
+++ b/mappings/CommunityAPI_GetPerson_XCMSG3I.json
@@ -1,5 +1,4 @@
 {
-  "id": "c8053a0c-2804-4cab-aaf3-9f455a3b87ac",
   "name": "community_api_getPerson_XCMSG3I",
   "request": {
     "url": "/secure/offenders/crn/XCMSG3I",

--- a/mappings/CommunityAPI_GetPerson_YRPARSH.json
+++ b/mappings/CommunityAPI_GetPerson_YRPARSH.json
@@ -1,5 +1,4 @@
 {
-  "id": "d709dae2-b6b8-453a-b650-4ad89f29b15d",
   "name": "community_api_getPerson_YRPARSH",
   "request": {
     "url": "/secure/offenders/crn/YRPARSH",

--- a/mappings/CommunityAPI_GetPerson_Z33A1BU.json
+++ b/mappings/CommunityAPI_GetPerson_Z33A1BU.json
@@ -1,5 +1,4 @@
 {
-  "id": "0448ea67-4085-4701-b0bb-e9ecf17f4978",
   "name": "community_api_getPerson_Z33A1BU",
   "request": {
     "url": "/secure/offenders/crn/Z33A1BU",

--- a/mappings/CommunityAPI_GetUser.json
+++ b/mappings/CommunityAPI_GetUser.json
@@ -1,0 +1,49 @@
+{
+  "id": "7baba015-16b5-4233-95de-f308a8de684a",
+  "name": "community_api_get_user",
+  "request": {
+    "urlPathPattern": "/secure/staff/username/(.*)",
+    "method": "GET"
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+        "username": "JimSnowLdap",
+        "email": "jim.snow@justice.gov.uk",
+        "telephoneNumber": "01512112121",
+        "staffCode": "SH00007",
+        "staffIdentifier": 17,
+        "staff": {
+            "forenames": "JIM",
+            "surname": "SNOW"
+        },
+        "probationArea": {
+            "probationAreaId": 12,
+            "code": "GCS",
+            "description": "Gloucestershire",
+            "organisation": {
+                "code": "SW",
+                "description": "South West"
+            }
+        },
+        "staffGrade": {
+            "code": "M",
+            "description": "PO"
+        }
+    },
+    "headers": {
+      "X-Content-Type-Options": "nosniff",
+      "X-XSS-Protection": "1; mode=block",
+      "Cache-Control": "no-cache, no-store, max-age=0, must-revalidate",
+      "Pragma": "no-cache",
+      "Expires": "0",
+      "X-Frame-Options": "DENY",
+      "vary": "accept-encoding",
+      "Content-Type": "application/json",
+      "Date": "Mon, 19 Dec 2022 16:16:21 GMT",
+      "Keep-Alive": "timeout=60"
+    }
+  },
+  "uuid": "24632c7a-875f-4c1f-aeea-20643413bf95",
+  "persistent": true
+}

--- a/mappings/CommunityAPI_GetUser_AP_TEST_USER_1.json
+++ b/mappings/CommunityAPI_GetUser_AP_TEST_USER_1.json
@@ -1,0 +1,34 @@
+{
+  "name": "community_api_get_user_AP_TEST_USER_1",
+  "request": {
+    "url": "/secure/staff/username/AP_TEST_USER_1",
+    "method": "GET"
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "username": "AP_TEST_USER_1",
+      "email": "stuart.harrison2+test1@digital.justice.gov.uk",
+      "telephoneNumber": "01512112121",
+      "staffCode": "SH00007",
+      "staffIdentifier": 17,
+      "staff": {
+        "forenames": "AP Test User 1",
+        "surname": ""
+      },
+      "probationArea": {
+        "probationAreaId": 12,
+        "code": "GCS",
+        "description": "Gloucestershire",
+        "organisation": {
+          "code": "SW",
+          "description": "South West"
+        }
+      },
+      "staffGrade": {
+        "code": "M",
+        "description": "PO"
+      }
+    }
+  }
+}

--- a/mappings/CommunityAPI_GetUser_AP_TEST_USER_2.json
+++ b/mappings/CommunityAPI_GetUser_AP_TEST_USER_2.json
@@ -1,0 +1,34 @@
+{
+  "name": "community_api_get_user_AP_TEST_USER_2",
+  "request": {
+    "url": "/secure/staff/username/AP_TEST_USER_2",
+    "method": "GET"
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "username": "AP_TEST_USER_2",
+      "email": "stuart.harrison2+test2@digital.justice.gov.uk",
+      "telephoneNumber": "01512112121",
+      "staffCode": "SH00007",
+      "staffIdentifier": 17,
+      "staff": {
+        "forenames": "AP Test User 2",
+        "surname": ""
+      },
+      "probationArea": {
+        "probationAreaId": 12,
+        "code": "GCS",
+        "description": "Gloucestershire",
+        "organisation": {
+          "code": "SW",
+          "description": "South West"
+        }
+      },
+      "staffGrade": {
+        "code": "M",
+        "description": "PO"
+      }
+    }
+  }
+}

--- a/mappings/CommunityAPI_GetUser_AP_TEST_USER_3.json
+++ b/mappings/CommunityAPI_GetUser_AP_TEST_USER_3.json
@@ -1,0 +1,34 @@
+{
+  "name": "community_api_get_user_AP_TEST_USER_3",
+  "request": {
+    "url": "/secure/staff/username/AP_TEST_USER_3",
+    "method": "GET"
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "username": "AP_TEST_USER_3",
+      "email": "stuart.harrison2+test3@digital.justice.gov.uk",
+      "telephoneNumber": "01512112121",
+      "staffCode": "SH00007",
+      "staffIdentifier": 17,
+      "staff": {
+        "forenames": "AP Test User 3",
+        "surname": ""
+      },
+      "probationArea": {
+        "probationAreaId": 12,
+        "code": "GCS",
+        "description": "Gloucestershire",
+        "organisation": {
+          "code": "SW",
+          "description": "South West"
+        }
+      },
+      "staffGrade": {
+        "code": "M",
+        "description": "PO"
+      }
+    }
+  }
+}

--- a/mappings/CommunityAPI_GetUser_AP_TEST_USER_4.json
+++ b/mappings/CommunityAPI_GetUser_AP_TEST_USER_4.json
@@ -1,0 +1,34 @@
+{
+  "name": "community_api_get_user_AP_TEST_USER_4",
+  "request": {
+    "url": "/secure/staff/username/AP_TEST_USER_4",
+    "method": "GET"
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "username": "AP_TEST_USER_4",
+      "email": "stuart.harrison2+test4@digital.justice.gov.uk",
+      "telephoneNumber": "01512112121",
+      "staffCode": "SH00007",
+      "staffIdentifier": 17,
+      "staff": {
+        "forenames": "AP Test User 4",
+        "surname": ""
+      },
+      "probationArea": {
+        "probationAreaId": 12,
+        "code": "GCS",
+        "description": "Gloucestershire",
+        "organisation": {
+          "code": "SW",
+          "description": "South West"
+        }
+      },
+      "staffGrade": {
+        "code": "M",
+        "description": "PO"
+      }
+    }
+  }
+}

--- a/mappings/CommunityAPI_GetUser_AP_TEST_USER_5.json
+++ b/mappings/CommunityAPI_GetUser_AP_TEST_USER_5.json
@@ -1,0 +1,34 @@
+{
+  "name": "community_api_get_user_AP_TEST_USER_5",
+  "request": {
+    "url": "/secure/staff/username/AP_TEST_USER_5",
+    "method": "GET"
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "username": "AP_TEST_USER_5",
+      "email": "stuart.harrison2+test5@digital.justice.gov.uk",
+      "telephoneNumber": "01512112121",
+      "staffCode": "SH00007",
+      "staffIdentifier": 17,
+      "staff": {
+        "forenames": "AP Test User 5",
+        "surname": ""
+      },
+      "probationArea": {
+        "probationAreaId": 12,
+        "code": "GCS",
+        "description": "Gloucestershire",
+        "organisation": {
+          "code": "SW",
+          "description": "South West"
+        }
+      },
+      "staffGrade": {
+        "code": "M",
+        "description": "PO"
+      }
+    }
+  }
+}

--- a/script/generate_mappings
+++ b/script/generate_mappings
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# script/generate_mappings: Generate/Regenerate mappings for users and offenders
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+echo "==> Generating offender mappings"
+node utils/generateOffenderMappings.js
+
+echo "==> Generating user mappings"
+node utils/generateUserMappings.js

--- a/script/generate_migrations
+++ b/script/generate_migrations
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+# script/generate_migrations: Generate/Regenerate migrations for the test
+# instance of the API
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+apiDir=$1
+
+if [ -z "$apiDir" ]; then
+  echo "Usage - 'script/generate_migrations API_DIRECTORY' "
+  exit 1
+fi
+
+if [ ! -d "$apiDir" ]; then
+  echo "Directory $apiDir not found"
+  exit 1
+fi
+
+rm -rf /tmp/migrations
+mkdir /tmp/migrations
+
+userFileName="R__1_create_users.sql"
+userFilePath="/tmp/migrations/$userFileName"
+
+echo "==> Creating migration: $userFileName"
+touch "$userFilePath"
+node utils/generateUserSql.js > "$userFilePath"
+
+bookingFileName="R__2_create_bookings.sql"
+bookingFilePath="/tmp/migrations/$bookingFileName"
+
+echo "==> Creating migration: $bookingFileName"
+touch "$bookingFilePath"
+node utils/generateBookingSql.js > "$bookingFilePath"
+
+applicationFilename="R__3_create_applications.sql"
+applicationFilePath="/tmp/migrations/$applicationFilename"
+
+echo "==> Creating migration: $applicationFilename"
+touch "$applicationFilePath"
+node utils/generateApplicationSql.js > "$applicationFilePath"
+
+echo "==> Copying migrations to $apiDir"
+mv /tmp/migrations/*.sql "${apiDir}/src/main/resources/db/migration/test"

--- a/utils/generateApplicationSql.js
+++ b/utils/generateApplicationSql.js
@@ -1,0 +1,117 @@
+const crypto = require('crypto')
+
+const applicationData = require('../data/applicationData.json')
+const applicationDocument = require('../data/applicationDocument.json')
+const users = require('../data/users.json')
+const offenders = require('../data/offenders.json')
+
+const crns = offenders.map(o => o.otherIds.crn)
+const randomUser = () => users[Math.floor(Math.random() * users.length)]
+
+sql = []
+
+sql.push(`
+-- \${flyway:timestamp}
+TRUNCATE TABLE applications CASCADE;
+TRUNCATE TABLE assessments CASCADE;
+`)
+
+sql.push(`
+DO $$
+DECLARE
+   applicationData json := '${JSON.stringify(applicationData)}';
+   applicationDocument json := '${JSON.stringify(applicationDocument)}';
+BEGIN
+`)
+
+crns.forEach(crn => {
+  const applicationId = crypto.randomUUID()
+  sql.push(`
+  insert into applications (
+    "id",
+    "created_at",
+    "created_by_user_id",
+    "crn",
+    "data",
+    "document",
+    "schema_version",
+    "service",
+    "submitted_at"
+  )
+  values
+    (
+      '${applicationId}',
+      CURRENT_DATE + ${Math.floor(Math.random() * 30)},
+      '${randomUser().id}',
+      '${crn}',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + ${Math.floor(Math.random() * 30)}
+    );
+  `)
+
+  sql.push(`
+  insert into approved_premises_applications (
+      "conviction_id",
+      "event_number",
+      "id",
+      "is_pipe_application",
+      "is_womens_application",
+      "offence_id",
+      "risk_ratings"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      '${applicationId}',
+      false,
+      false,
+      'M2500295343',
+      '{"roshRisks":{"status":"Error","value":null},"mappa":{"status":"Retrieved","value":{"level":"CAT M2/LEVEL M2","lastUpdated":[2021,2,1]}},"tier":{"status":"Retrieved","value":{"level":"D2","lastUpdated":[2022,9,5]}},"flags":{"status":"Retrieved","value":["Risk to Known Adult"]}}'
+    );
+  `)
+
+  sql.push(`
+  INSERT into
+  assessments (
+    "id",
+    "application_id",
+    "allocated_to_user_id",
+    "created_at",
+    "allocated_at",
+    "schema_version"
+  )
+  VALUES
+    (
+      '${crypto.randomUUID()}',
+      '${applicationId}',
+      '${randomUser().id}',
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+  `)
+})
+
+sql.push(`END $$;`)
+
+console.log(sql.join('\r\n'))

--- a/utils/generateBookingSql.js
+++ b/utils/generateBookingSql.js
@@ -1,0 +1,108 @@
+const crypto = require('crypto')
+
+const offenders = require('../data/offenders.json')
+
+const crns = offenders.map(o => o.otherIds.crn)
+
+const insertBooking = (crn, arrival_date, departure_date, id = crypto.randomUUID()) => {
+  return `
+INSERT INTO
+  bookings (
+    "id",
+    "arrival_date",
+    "departure_date",
+    "crn",
+    "original_arrival_date",
+    "original_departure_date",
+    "premises_id",
+    "service",
+    "created_at"
+  )
+VALUES
+  (
+    '${id}',
+    ${arrival_date},
+    ${departure_date},
+    '${crn}',
+    ${arrival_date},
+    ${departure_date},
+    '459eeaba-55ac-4a1f-bae2-bad810d4016b',
+    'approved-premises',
+    CURRENT_DATE
+  );
+`
+}
+
+const insertArrival = (arrivalDate, bookingId, expectedDepartureDate) => {
+  return `
+INSERT INTO
+  arrivals (
+    "arrival_date",
+    "booking_id",
+    "created_at",
+    "expected_departure_date",
+    "id",
+    "notes"
+  )
+VALUES
+  (
+    ${arrivalDate},
+    '${bookingId}',
+    CURRENT_DATE,
+    ${expectedDepartureDate},
+    '${crypto.randomUUID()}',
+    NULL
+  );
+  `
+}
+
+const insertArrivedBooking = (crn, arrival_date, departure_date) => {
+  sql = []
+  bookingId = crypto.randomUUID()
+  sql.push(
+    insertBooking(crn, arrival_date, departure_date, bookingId)
+  )
+  sql.push(
+    insertArrival(arrival_date, bookingId, departure_date)
+  )
+
+  return sql.join('\r\n')
+}
+
+const arrivingToday = [crns[0], crns[1], crns[2]].map(
+  crn => insertBooking(crn, 'CURRENT_DATE', 'CURRENT_DATE + 84')
+)
+
+const dueToArrive = [crns[3], crns[4], crns[6], crns[7]].map(
+  crn => insertBooking(crn, `CURRENT_DATE + ${Math.floor(Math.random() * 4) + 1}`, 'CURRENT_DATE + 84')
+)
+
+const departingToday = [crns[8], crns[9]].map(
+  crn => insertArrivedBooking(crn, 'CURRENT_DATE - 84', 'CURRENT_DATE')
+)
+
+const departingSoon = [crns[8], crns[9]].map(
+  crn => insertArrivedBooking(crn, 'CURRENT_DATE - 84', `CURRENT_DATE + ${Math.floor(Math.random() * 4) + 1}`)
+)
+
+const currentBookings = [crns[10], crns[11], crns[12], crns[13], crns[15]].map(
+  crn => insertArrivedBooking(crn, 'CURRENT_DATE - 7', `CURRENT_DATE + ${Math.floor(Math.random() * 60) + 1}`)
+)
+
+console.log(
+  `
+-- \${flyway:timestamp}
+TRUNCATE TABLE arrivals CASCADE;
+TRUNCATE TABLE bookings CASCADE;
+--- Add some Bookings arriving today ---
+${arrivingToday.join('\r\n')}
+--- Add some Bookings arriving soon ---
+${dueToArrive.join('\r\n')}
+--- Add some Bookings departing today ---
+${departingToday.join('\r\n')}
+--- Add some Bookings departing soon ---
+${departingSoon.join('\r\n')}
+--- Add some arrived Bookings ---
+${currentBookings.join('\r\n')}
+  `
+)

--- a/utils/generateOffenderMappings.js
+++ b/utils/generateOffenderMappings.js
@@ -1,0 +1,19 @@
+const offenders = require('../data/offenders.json')
+const fs = require('fs');
+
+offenders.forEach(offender => {
+  const crn = offender.otherIds.crn
+  const filename = `CommunityAPI_GetPerson_${crn}.json`
+  const body = {
+    "name": `community_api_getPerson_${crn}`,
+    "request": {
+      "url": `/secure/offenders/crn/${crn}`,
+      "method": "GET"
+    },
+    "response": {
+      "status": 200,
+      "jsonBody": offender
+    }
+  }
+  fs.writeFileSync(`${__dirname}/../mappings/${filename}`, JSON.stringify(body, null, 2), { flag: 'w+' });
+})

--- a/utils/generateUserMappings.js
+++ b/utils/generateUserMappings.js
@@ -1,0 +1,41 @@
+const users = require('../data/users.json')
+const fs = require('fs');
+
+users.forEach(user => {
+  const filename = `CommunityAPI_GetUser_${user.username}.json`
+  const body = {
+    "name": `community_api_get_user_${user.username}`,
+    "request": {
+      "url": `/secure/staff/username/${user.username}`,
+      "method": "GET"
+    },
+    "response": {
+      "status": 200,
+      "jsonBody": {
+        "username": user.username,
+        "email": user.email,
+        "telephoneNumber": "01512112121",
+        "staffCode": "SH00007",
+        "staffIdentifier": 17,
+        "staff": {
+            "forenames": user.name,
+            "surname": ""
+        },
+        "probationArea": {
+            "probationAreaId": 12,
+            "code": "GCS",
+            "description": "Gloucestershire",
+            "organisation": {
+                "code": "SW",
+                "description": "South West"
+            }
+        },
+        "staffGrade": {
+            "code": "M",
+            "description": "PO"
+        }
+      }
+    }
+  }
+  fs.writeFileSync(`${__dirname}/../mappings/${filename}`, JSON.stringify(body, null, 2), { flag: 'w+' });
+})

--- a/utils/generateUserSql.js
+++ b/utils/generateUserSql.js
@@ -1,0 +1,24 @@
+const users = require('../data/users.json')
+
+const sql = users.map(u => `
+  insert into
+    users (
+      "delius_staff_identifier",
+      "delius_username",
+      "id",
+      "name"
+    )
+  values
+    (
+      '${Math.floor(Math.random() * 100000)}',
+      '${u.username}',
+      '${u.id}',
+      '${u.name}'
+    );
+`)
+
+console.log(`
+-- \${flyway:timestamp}
+TRUNCATE TABLE users CASCADE;
+${sql.join('\r\n')}
+`)


### PR DESCRIPTION
This adds some helper scripts to generate new stubs, based on a corpus of user and person data. We also have an additional script that uses the same corpus to generate migrations that create new users, applications, assessments and bookings in the test API databases. 

The work to implement the migrations is in the API repo here - https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/319