### PR TITLE
Prepare for golive

### DIFF
--- a/data/users.json
+++ b/data/users.json
@@ -28,5 +28,17 @@
     "username": "AP_TEST_USER_5",
     "name": "AP Test User 5",
     "email": "stuart.harrison2+test5@digital.justice.gov.uk"
+  },
+  {
+    "id": "7e8d1738-a07d-4ba4-a8a7-9b7d9c9d27b2",
+    "username": "CAS_NCC_TEST1",
+    "name": "NCC User 1",
+    "email": "user1@20230222.CAS31.nccpentest.com"
+  },
+  {
+    "id": "f9ff1c6e-6876-4ba8-8ca9-d7d2c6f673dc",
+    "username": "CAS_NCC_TEST2",
+    "name": "NCC User 2",
+    "email": "user2@20230222.CAS31.nccpentest.com"
   }
 ]

--- a/helm_deploy/hmpps-community-accommodation-wiremock/values.yaml
+++ b/helm_deploy/hmpps-community-accommodation-wiremock/values.yaml
@@ -9,6 +9,8 @@ generic-service:
     tag: app_version # override at deployment time
     port: 8080
 
+  containerArgs: ["--no-request-journal"]
+
   ingress:
     enabled: true
     hosts:

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -10,7 +10,20 @@ generic-service:
     contextColour: green
     tlsSecretName: hmpps-community-accommodation-wiremock-test-cert
 
-  allowlist: null
+  allowlist:
+    unilink-aovpn1: "194.75.210.216/29"
+    unilink-aovpn2: "83.98.63.176/29"
+    unilink-aovpn3: "78.33.10.50/31"
+    unilink-aovpn4: "78.33.10.52/30"
+    unilink-aovpn5: "78.33.10.56/30"
+    unilink-aovpn6: "78.33.10.60/32"
+    unilink-aovpn7: "78.33.32.99/32"
+    unilink-aovpn8: "78.33.32.100/30"
+    unilink-aovpn9: "78.33.32.104/30"
+    unilink-aovpn10: "78.33.32.108/32"
+    unilink-aovpn11: "217.138.45.109/32"
+    unilink-aovpn12: "217.138.45.110/32"
+
 
 generic-prometheus-alerts:
   alertSeverity: digital-prison-service-dev

--- a/mappings/CommunityAPI_GetUser_CAS_NCC_TEST1.json
+++ b/mappings/CommunityAPI_GetUser_CAS_NCC_TEST1.json
@@ -1,0 +1,34 @@
+{
+  "name": "community_api_get_user_CAS_NCC_TEST1",
+  "request": {
+    "url": "/secure/staff/username/CAS_NCC_TEST1",
+    "method": "GET"
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "username": "CAS_NCC_TEST1",
+      "email": "user1@20230222.CAS31.nccpentest.com",
+      "telephoneNumber": "01512112121",
+      "staffCode": "SH00007",
+      "staffIdentifier": 17,
+      "staff": {
+        "forenames": "NCC User 1",
+        "surname": ""
+      },
+      "probationArea": {
+        "probationAreaId": 12,
+        "code": "GCS",
+        "description": "Gloucestershire",
+        "organisation": {
+          "code": "SW",
+          "description": "South West"
+        }
+      },
+      "staffGrade": {
+        "code": "M",
+        "description": "PO"
+      }
+    }
+  }
+}

--- a/mappings/CommunityAPI_GetUser_CAS_NCC_TEST2.json
+++ b/mappings/CommunityAPI_GetUser_CAS_NCC_TEST2.json
@@ -1,0 +1,34 @@
+{
+  "name": "community_api_get_user_CAS_NCC_TEST2",
+  "request": {
+    "url": "/secure/staff/username/CAS_NCC_TEST2",
+    "method": "GET"
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "username": "CAS_NCC_TEST2",
+      "email": "user2@20230222.CAS31.nccpentest.com",
+      "telephoneNumber": "01512112121",
+      "staffCode": "SH00007",
+      "staffIdentifier": 17,
+      "staff": {
+        "forenames": "NCC User 2",
+        "surname": ""
+      },
+      "probationArea": {
+        "probationAreaId": 12,
+        "code": "GCS",
+        "description": "Gloucestershire",
+        "organisation": {
+          "code": "SW",
+          "description": "South West"
+        }
+      },
+      "staffGrade": {
+        "code": "M",
+        "description": "PO"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds the pentest users to the stubs, as well as locking down access and removing the requestJournal (which records all requests made to Wiremock)