### PR TITLE
Generate Temporary Accommodation bookings with states

### DIFF
--- a/data/rooms.json
+++ b/data/rooms.json
@@ -53,5 +53,64 @@
         "id": "8be1ed0e-dae7-42d2-97e0-95c95fdb4c50"
       }
     ]
+  },
+  {
+    "id": "a82a64f0-a9b6-4854-a5c6-eecb16d8724a",
+    "name": "ROOM6",
+    "premisesId": "b6a87a7e-1b6a-4c96-b7ff-8c0dc414796d",
+    "beds": [
+      {
+        "name": "default-bed",
+        "id": "bdf9f9f6-6d53-4577-bffe-fc5f0ab3de0f"
+      }
+    ]
+  },
+  {
+    "id": "1363dca9-baac-46d4-b045-1da39b7aa46d",
+    "name": "ROOM7",
+    "premisesId": "ada106c7-e1fb-409a-a38e-0002ea8e7e45",
+    "createBooking": false,
+    "beds": [
+      {
+        "name": "default-bed",
+        "id": "055f1f4a-4f86-4ed1-80dc-b793f96c3003"
+      }
+    ]
+  },
+  {
+    "id": "53ab0bb3-1553-46e8-877b-6ce6a7ee5d3c",
+    "name": "ROOM8",
+    "premisesId": "ada106c7-e1fb-409a-a38e-0002ea8e7e45",
+    "createBooking": false,
+    "beds": [
+      {
+        "name": "default-bed",
+        "id": "5f307ee5-e53a-47b3-85b1-a85f0436d9bb"
+      }
+    ]
+  },
+  {
+    "id": "6f8f50e9-0467-46fa-964b-20d901078631",
+    "name": "ROOM9",
+    "premisesId": "36c7b1f2-5a4b-467b-838c-2970c9c253cf",
+    "createBooking": false,
+    "beds": [
+      {
+        "name": "default-bed",
+        "id": "a9c6a648-bb73-4d03-b670-a01e3d67dc7a"
+      }
+    ]
+  },
+  {
+    "id": "390883bb-9689-4e17-bfd6-2a762ae182a2",
+    "name": "ROOM10",
+    "premisesId": "36c7b1f2-5a4b-467b-838c-2970c9c253cf",
+    "createBooking": false,
+    "beds": [
+      {
+        "name": "default-bed",
+        "id": "8eb3fa96-48fe-4e24-8015-16bf009ad5ca"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
> See [ticket #728 on the CAS3 Trello board](https://trello.com/c/TnBc30u6/728-add-seed-data-to-the-api-for-the-test-environment-to-enable-training).

This PR enhances how bookings for Temporary Accommodation premises are generated:
- An `INSERT` statement can be generated for each booking state table used by Temporary Accommodation
- A Temporary Accommodation booking can be created with the desired state using `insertTABookingWithStatus()`, which generates the booking and state queries as appropriate
- A room defined in `rooms.json` can skip having a booking generated for it by adding `"createBooking": false` to it

Additionally, `rooms.json` has been modified to provide rooms for all the Temporary Accommodation premises that the dev/test environment is seeded with, to provide the following scenarios:
- At least one room with a booking for each booking state
- Rooms that have no bookings
- Both single and shared properties

This PR relates to https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/366 as it is used to generate the updated migrations in that PR.