### PR TITLE
Set lower priority for offender details endpoint

### DIFF
--- a/mappings/CommunityAPI_GetPerson.json
+++ b/mappings/CommunityAPI_GetPerson.json
@@ -1,5 +1,6 @@
 {
   "name": "community_api_getPerson_4Y29R9P",
+  "priority": 10,
   "request": {
     "urlPathPattern": "/secure/offenders/crn/(.*)",
     "method": "GET"

--- a/mappings/CommunityAPI_GetPerson_315VWWC.json
+++ b/mappings/CommunityAPI_GetPerson_315VWWC.json
@@ -1,5 +1,6 @@
 {
   "name": "community_api_getPerson_315VWWC",
+  "priority": 10,
   "request": {
     "url": "/secure/offenders/crn/315VWWC",
     "method": "GET"

--- a/mappings/CommunityAPI_GetPerson_4Y29R9P.json
+++ b/mappings/CommunityAPI_GetPerson_4Y29R9P.json
@@ -1,5 +1,6 @@
 {
   "name": "community_api_getPerson_4Y29R9P",
+  "priority": 10,
   "request": {
     "url": "/secure/offenders/crn/4Y29R9P",
     "method": "GET"

--- a/mappings/CommunityAPI_GetPerson_4ZUIHFX.json
+++ b/mappings/CommunityAPI_GetPerson_4ZUIHFX.json
@@ -1,5 +1,6 @@
 {
   "name": "community_api_getPerson_4ZUIHFX",
+  "priority": 10,
   "request": {
     "url": "/secure/offenders/crn/4ZUIHFX",
     "method": "GET"

--- a/mappings/CommunityAPI_GetPerson_52W7TQG.json
+++ b/mappings/CommunityAPI_GetPerson_52W7TQG.json
@@ -1,5 +1,6 @@
 {
   "name": "community_api_getPerson_52W7TQG",
+  "priority": 10,
   "request": {
     "url": "/secure/offenders/crn/52W7TQG",
     "method": "GET"

--- a/mappings/CommunityAPI_GetPerson_5EC66UT.json
+++ b/mappings/CommunityAPI_GetPerson_5EC66UT.json
@@ -1,5 +1,6 @@
 {
   "name": "community_api_getPerson_5EC66UT",
+  "priority": 10,
   "request": {
     "url": "/secure/offenders/crn/5EC66UT",
     "method": "GET"

--- a/mappings/CommunityAPI_GetPerson_8LO3HSH.json
+++ b/mappings/CommunityAPI_GetPerson_8LO3HSH.json
@@ -1,5 +1,6 @@
 {
   "name": "community_api_getPerson_8LO3HSH",
+  "priority": 10,
   "request": {
     "url": "/secure/offenders/crn/8LO3HSH",
     "method": "GET"

--- a/mappings/CommunityAPI_GetPerson_BWEFOI7.json
+++ b/mappings/CommunityAPI_GetPerson_BWEFOI7.json
@@ -1,5 +1,6 @@
 {
   "name": "community_api_getPerson_BWEFOI7",
+  "priority": 10,
   "request": {
     "url": "/secure/offenders/crn/BWEFOI7",
     "method": "GET"

--- a/mappings/CommunityAPI_GetPerson_GSR1T2F.json
+++ b/mappings/CommunityAPI_GetPerson_GSR1T2F.json
@@ -1,5 +1,6 @@
 {
   "name": "community_api_getPerson_GSR1T2F",
+  "priority": 10,
   "request": {
     "url": "/secure/offenders/crn/GSR1T2F",
     "method": "GET"

--- a/mappings/CommunityAPI_GetPerson_HRV83TE.json
+++ b/mappings/CommunityAPI_GetPerson_HRV83TE.json
@@ -1,5 +1,6 @@
 {
   "name": "community_api_getPerson_HRV83TE",
+  "priority": 10,
   "request": {
     "url": "/secure/offenders/crn/HRV83TE",
     "method": "GET"

--- a/mappings/CommunityAPI_GetPerson_HTVI42B.json
+++ b/mappings/CommunityAPI_GetPerson_HTVI42B.json
@@ -1,5 +1,6 @@
 {
   "name": "community_api_getPerson_HTVI42B",
+  "priority": 10,
   "request": {
     "url": "/secure/offenders/crn/HTVI42B",
     "method": "GET"

--- a/mappings/CommunityAPI_GetPerson_HUN3BN0.json
+++ b/mappings/CommunityAPI_GetPerson_HUN3BN0.json
@@ -1,5 +1,6 @@
 {
   "name": "community_api_getPerson_HUN3BN0",
+  "priority": 10,
   "request": {
     "url": "/secure/offenders/crn/HUN3BN0",
     "method": "GET"

--- a/mappings/CommunityAPI_GetPerson_IHGHXYM.json
+++ b/mappings/CommunityAPI_GetPerson_IHGHXYM.json
@@ -1,5 +1,6 @@
 {
   "name": "community_api_getPerson_IHGHXYM",
+  "priority": 10,
   "request": {
     "url": "/secure/offenders/crn/IHGHXYM",
     "method": "GET"

--- a/mappings/CommunityAPI_GetPerson_JCRH9V5.json
+++ b/mappings/CommunityAPI_GetPerson_JCRH9V5.json
@@ -1,5 +1,6 @@
 {
   "name": "community_api_getPerson_JCRH9V5",
+  "priority": 10,
   "request": {
     "url": "/secure/offenders/crn/JCRH9V5",
     "method": "GET"

--- a/mappings/CommunityAPI_GetPerson_N6OUTAY.json
+++ b/mappings/CommunityAPI_GetPerson_N6OUTAY.json
@@ -1,5 +1,6 @@
 {
   "name": "community_api_getPerson_N6OUTAY",
+  "priority": 10,
   "request": {
     "url": "/secure/offenders/crn/N6OUTAY",
     "method": "GET"

--- a/mappings/CommunityAPI_GetPerson_PI251LM.json
+++ b/mappings/CommunityAPI_GetPerson_PI251LM.json
@@ -1,5 +1,6 @@
 {
   "name": "community_api_getPerson_PI251LM",
+  "priority": 10,
   "request": {
     "url": "/secure/offenders/crn/PI251LM",
     "method": "GET"

--- a/mappings/CommunityAPI_GetPerson_PR5E5Y2.json
+++ b/mappings/CommunityAPI_GetPerson_PR5E5Y2.json
@@ -1,5 +1,6 @@
 {
   "name": "community_api_getPerson_PR5E5Y2",
+  "priority": 10,
   "request": {
     "url": "/secure/offenders/crn/PR5E5Y2",
     "method": "GET"

--- a/mappings/CommunityAPI_GetPerson_QA93YYK.json
+++ b/mappings/CommunityAPI_GetPerson_QA93YYK.json
@@ -1,5 +1,6 @@
 {
   "name": "community_api_getPerson_QA93YYK",
+  "priority": 10,
   "request": {
     "url": "/secure/offenders/crn/QA93YYK",
     "method": "GET"

--- a/mappings/CommunityAPI_GetPerson_XCMSG3I.json
+++ b/mappings/CommunityAPI_GetPerson_XCMSG3I.json
@@ -1,5 +1,6 @@
 {
   "name": "community_api_getPerson_XCMSG3I",
+  "priority": 10,
   "request": {
     "url": "/secure/offenders/crn/XCMSG3I",
     "method": "GET"

--- a/mappings/CommunityAPI_GetPerson_YRPARSH.json
+++ b/mappings/CommunityAPI_GetPerson_YRPARSH.json
@@ -1,5 +1,6 @@
 {
   "name": "community_api_getPerson_YRPARSH",
+  "priority": 10,
   "request": {
     "url": "/secure/offenders/crn/YRPARSH",
     "method": "GET"

--- a/mappings/CommunityAPI_GetPerson_Z33A1BU.json
+++ b/mappings/CommunityAPI_GetPerson_Z33A1BU.json
@@ -1,5 +1,6 @@
 {
   "name": "community_api_getPerson_Z33A1BU",
+  "priority": 10,
   "request": {
     "url": "/secure/offenders/crn/Z33A1BU",
     "method": "GET"
@@ -36,7 +37,7 @@
       "softDeleted": false,
       "currentDisposal": "1",
       "partitionArea": "National Data",
-      "currentRestriction": true,
+      "currentRestriction": false,
       "currentExclusion": false,
       "activeProbationManagedSentence": true
     }

--- a/utils/generateOffenderMappings.js
+++ b/utils/generateOffenderMappings.js
@@ -6,6 +6,7 @@ offenders.forEach(offender => {
   const filename = `CommunityAPI_GetPerson_${crn}.json`
   const body = {
     "name": `community_api_getPerson_${crn}`,
+    "priority": 10,
     "request": {
       "url": `/secure/offenders/crn/${crn}`,
       "method": "GET"


### PR DESCRIPTION
To prevent this greedily matching against more specific routes, set the priority to 10 which is lower than the default of 5.