### PR TITLE
Leave existing users in place when generating seed migration

### DIFF
--- a/utils/generateUserSql.js
+++ b/utils/generateUserSql.js
@@ -14,11 +14,12 @@ const sql = users.map(u => `
       '${u.username}',
       '${u.id}',
       '${u.name}'
-    );
+    )
+  ON CONFLICT (id) DO NOTHING;
 `)
 
 console.log(`
 -- \${flyway:timestamp}
-TRUNCATE TABLE users CASCADE;
+
 ${sql.join('\r\n')}
 `)


### PR DESCRIPTION
... as seeding is also done via remotely run "seed jobs" and we don't want those users to be lost on every migration/deployment.

See also https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/373