### PR TITLE
Generate probation region data for users

### DIFF
--- a/data/users.json
+++ b/data/users.json
@@ -3,42 +3,56 @@
     "id": "7a424213-3a0c-45b0-9a51-4977243c2b21",
     "username": "AP_USER_TEST_1",
     "name": "AP Test User 1",
-    "email": "stuart.harrison2+test1@digital.justice.gov.uk"
+    "email": "stuart.harrison2+test1@digital.justice.gov.uk",
+    "probation_region_code": "N58",
+    "probation_region_id": "43606be0-9836-441d-9bc1-5586de9ac931"
   },
   {
     "id": "8a39870c-3a1f-4e05-ad45-a450e15b242d",
     "username": "AP_USER_TEST_2",
     "name": "AP Test User 2",
-    "email": "stuart.harrison2+test2@digital.justice.gov.uk"
+    "email": "stuart.harrison2+test2@digital.justice.gov.uk",
+    "probation_region_code": "N58",
+    "probation_region_id": "43606be0-9836-441d-9bc1-5586de9ac931"
   },
   {
     "id": "68715a03-06af-49ee-bae5-039c824ab9af",
     "username": "AP_USER_TEST_3",
     "name": "AP Test User 3",
-    "email": "stuart.harrison2+test3@digital.justice.gov.uk"
+    "email": "stuart.harrison2+test3@digital.justice.gov.uk",
+    "probation_region_code": "N58",
+    "probation_region_id": "43606be0-9836-441d-9bc1-5586de9ac931"
   },
   {
     "id": "6dcd2559-2d14-4feb-8faf-89ad30dfa765",
     "username": "AP_USER_TEST_4",
     "name": "AP Test User 4",
-    "email": "stuart.harrison2+test4@digital.justice.gov.uk"
+    "email": "stuart.harrison2+test4@digital.justice.gov.uk",
+    "probation_region_code": "N58",
+    "probation_region_id": "43606be0-9836-441d-9bc1-5586de9ac931"
   },
   {
     "id": "531455f4-c76f-4943-b4eb-3c02d8fefa69",
     "username": "AP_USER_TEST_5",
     "name": "AP Test User 5",
-    "email": "stuart.harrison2+test5@digital.justice.gov.uk"
+    "email": "stuart.harrison2+test5@digital.justice.gov.uk",
+    "probation_region_code": "N58",
+    "probation_region_id": "43606be0-9836-441d-9bc1-5586de9ac931"
   },
   {
     "id": "7e8d1738-a07d-4ba4-a8a7-9b7d9c9d27b2",
     "username": "CAS_NCC_TEST1",
     "name": "NCC User 1",
-    "email": "user1@20230222.CAS31.nccpentest.com"
+    "email": "user1@20230222.CAS31.nccpentest.com",
+    "probation_region_code": "N58",
+    "probation_region_id": "43606be0-9836-441d-9bc1-5586de9ac931"
   },
   {
     "id": "f9ff1c6e-6876-4ba8-8ca9-d7d2c6f673dc",
     "username": "CAS_NCC_TEST2",
     "name": "NCC User 2",
-    "email": "user2@20230222.CAS31.nccpentest.com"
+    "email": "user2@20230222.CAS31.nccpentest.com",
+    "probation_region_code": "N58",
+    "probation_region_id": "43606be0-9836-441d-9bc1-5586de9ac931"
   }
 ]

--- a/mappings/CommunityAPI_GetUser.json
+++ b/mappings/CommunityAPI_GetUser.json
@@ -19,7 +19,7 @@
       },
       "probationArea": {
         "probationAreaId": 12,
-        "code": "GCS",
+        "code": "N58",
         "description": "Gloucestershire",
         "organisation": {
           "code": "SW",

--- a/mappings/CommunityAPI_GetUser_AP_USER_TEST_1.json
+++ b/mappings/CommunityAPI_GetUser_AP_USER_TEST_1.json
@@ -18,7 +18,7 @@
       },
       "probationArea": {
         "probationAreaId": 12,
-        "code": "GCS",
+        "code": "N58",
         "description": "Gloucestershire",
         "organisation": {
           "code": "SW",

--- a/mappings/CommunityAPI_GetUser_AP_USER_TEST_2.json
+++ b/mappings/CommunityAPI_GetUser_AP_USER_TEST_2.json
@@ -18,7 +18,7 @@
       },
       "probationArea": {
         "probationAreaId": 12,
-        "code": "GCS",
+        "code": "N58",
         "description": "Gloucestershire",
         "organisation": {
           "code": "SW",

--- a/mappings/CommunityAPI_GetUser_AP_USER_TEST_3.json
+++ b/mappings/CommunityAPI_GetUser_AP_USER_TEST_3.json
@@ -18,7 +18,7 @@
       },
       "probationArea": {
         "probationAreaId": 12,
-        "code": "GCS",
+        "code": "N58",
         "description": "Gloucestershire",
         "organisation": {
           "code": "SW",

--- a/mappings/CommunityAPI_GetUser_AP_USER_TEST_4.json
+++ b/mappings/CommunityAPI_GetUser_AP_USER_TEST_4.json
@@ -18,7 +18,7 @@
       },
       "probationArea": {
         "probationAreaId": 12,
-        "code": "GCS",
+        "code": "N58",
         "description": "Gloucestershire",
         "organisation": {
           "code": "SW",

--- a/mappings/CommunityAPI_GetUser_AP_USER_TEST_5.json
+++ b/mappings/CommunityAPI_GetUser_AP_USER_TEST_5.json
@@ -18,7 +18,7 @@
       },
       "probationArea": {
         "probationAreaId": 12,
-        "code": "GCS",
+        "code": "N58",
         "description": "Gloucestershire",
         "organisation": {
           "code": "SW",

--- a/mappings/CommunityAPI_GetUser_CAS_NCC_TEST1.json
+++ b/mappings/CommunityAPI_GetUser_CAS_NCC_TEST1.json
@@ -18,7 +18,7 @@
       },
       "probationArea": {
         "probationAreaId": 12,
-        "code": "GCS",
+        "code": "N58",
         "description": "Gloucestershire",
         "organisation": {
           "code": "SW",

--- a/mappings/CommunityAPI_GetUser_CAS_NCC_TEST2.json
+++ b/mappings/CommunityAPI_GetUser_CAS_NCC_TEST2.json
@@ -18,7 +18,7 @@
       },
       "probationArea": {
         "probationAreaId": 12,
-        "code": "GCS",
+        "code": "N58",
         "description": "Gloucestershire",
         "organisation": {
           "code": "SW",

--- a/utils/generateUserMappings.js
+++ b/utils/generateUserMappings.js
@@ -14,7 +14,7 @@ const userBody = (user) => {
     },
     "probationArea": {
         "probationAreaId": 12,
-        "code": "GCS",
+        "code": user.probation_region_code,
         "description": "Gloucestershire",
         "organisation": {
             "code": "SW",
@@ -73,7 +73,8 @@ const defaultUser = {
   "id": "fe39c7ee-14af-4650-9263-f8e0e2cca970",
   "username": "DEFAULT_USER",
   "name": "Default User",
-  "email": "jim.snow@justice.gov.uk"
+  "email": "jim.snow@justice.gov.uk",
+  "probation_region_code": "N58"
 }
 const defaultFilename = `CommunityAPI_GetUser.json`
 const defaultBody = {

--- a/utils/generateUserSql.js
+++ b/utils/generateUserSql.js
@@ -6,14 +6,16 @@ const sql = users.map(u => `
       "delius_staff_identifier",
       "delius_username",
       "id",
-      "name"
+      "name",
+      "probation_region_id"
     )
   values
     (
       '${Math.floor(Math.random() * 100000)}',
       '${u.username}',
       '${u.id}',
-      '${u.name}'
+      '${u.name}',
+      '${u.probation_region_id}'
     )
   ON CONFLICT (id) DO NOTHING;
 `)


### PR DESCRIPTION
> See [ticket #714 on the CAS3 Trello board](https://trello.com/c/p0UPjpJn/714-api-can-retrieve-regional-information-about-a-member-of-staff).

This PR adds probation region data to users:
- `users.json` has been updated to include `probation_region_code` and `probation_region_id` fields for each user, to be used when generating the Community API Wiremock mappings and the test data migrations respectively.
- `generateUserMappings.js` now uses the probation region code for `$.probationArea.code` instead of the nonexistent code `"GCS"`.
- `generateUserSql.js` now adds the probation region ID as part of the generated `INSERT` statements.

Additionally, the Wiremock mapping files have been updated with the new data.

This PR is related to https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/385 as it is used to generate the updated migrations in that PR.