### PR TITLE
Add stub for managing caseload endpoint

### DIFF
--- a/mappings/ApDeliusContext_CheckManagingTeam.json
+++ b/mappings/ApDeliusContext_CheckManagingTeam.json
@@ -1,0 +1,18 @@
+{
+  "id": "19ee3e44-c13e-4d65-91d0-cb7b78e7c913",
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/teams/managingCase/(.*)"
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 200,
+    "jsonBody": {
+      "teamCodes": [
+        "TEAM1"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Since all the users are in "TEAM1", we return this for any request to the AP Delius Context API for the managing team for any CRN.