### PR TITLE
Fix Prison Alerts mapping

### DIFF
--- a/mappings/PrisonAPI_GetAlerts.json
+++ b/mappings/PrisonAPI_GetAlerts.json
@@ -1,9 +1,8 @@
 {
   "id": "c3a7a25a-cbbe-4920-b927-779b4a3cc61f",
   "name": "api_offenders_alerts",
-  "priority": 10,
   "request": {
-    "urlPathPattern": "/api/offenders/(.*)/alerts",
+    "urlPathPattern": "/api/offenders/(.*)/alerts/v2",
     "method": "GET"
   },
   "response": {


### PR DESCRIPTION
Remove priority 10 so this is prioritised over the offender details endpoint. Add missing /v2 to path